### PR TITLE
Check if LC_MESSAGES is defined

### DIFF
--- a/src/Fuel/Foundation/Error.php
+++ b/src/Fuel/Foundation/Error.php
@@ -127,10 +127,12 @@ class Error
 		$current_handler = set_exception_handler(function($e) use(&$current_handler)
 		{
 			// get the locale
-			if (defined('LC_MESSAGES')) {
+			if (defined('LC_MESSAGES'))
+			{
 				$locale = setlocale(LC_MESSAGES, null);                           
 			}
-			else {
+			else
+			{
 				$locale = setlocale(LC_ALL, null);
 			}
 


### PR DESCRIPTION
When I run the current github version I always get 
`Use of undefined constant LC_MESSAGES - assumed 'LC_MESSAGES'`
happens as soon as setlocale(LC_MESSAGES...) is called.

I've only tested this on Windows with PHP 5.4.9 and 5.5.3.
The extension gettext as well as intl are active.

It seems like there are more gettext related issues on Windows, I'll try to analyse them later.
This pull request only gets me past the first problem!
