### PR TITLE
Set component when it is different from the requested one

### DIFF
--- a/src/Request/Local.php
+++ b/src/Request/Local.php
@@ -80,6 +80,14 @@ class Local extends Base
 			}
 		}
 
+		// if the component is different then the requested one
+		if ($component !== $this->component)
+		{
+			// set it to the actual one
+			$this->component = $component;
+			$this->config = $component->getConfig();
+		}
+
 		// match found, resolve the route request
 		$this->route = $this->router->resolveRoute($this->request, $this->input->getMethod());
 


### PR DESCRIPTION
I started the issue [here](https://github.com/fuelphp/foundation/issues/12)

It attempts to solve the current component problem outlined there.

Not sure if it is the best possible solution, but shows how I imagine it.

@WanWizard please confirm that I am correct and the component in a request should be the component resolved by the router and not the one the request came from (usually the root component).
