### PR TITLE
Feature/request context

### DIFF
--- a/src/InjectionFactory.php
+++ b/src/InjectionFactory.php
@@ -188,6 +188,9 @@ class InjectionFactory
 		return $this->container->get('uri', array($uri));
 	}
 
+	/**
+	 * Checks if the current request is the "main" (only one)
+	 */
 	public function isMainRequest()
 	{
 		$stack = $this->container->get('requeststack');

--- a/src/Request/Local.php
+++ b/src/Request/Local.php
@@ -138,6 +138,15 @@ class Local extends Base
 		// add the root path to the config, lang and view manager objects
 		$paths = $this->component->getPaths();
 		$finder = $this->component->getApplication()->getViewManager()->getFinder();
+
+		if ( ! $this->factory->isMainRequest())
+		{
+			$originalFinder = $finder;
+			$finder = clone $finder;
+
+			$this->component->getApplication()->getViewManager()->setFinder($finder);
+		}
+
 		$finder->addPaths($paths);
 
 		try
@@ -164,7 +173,10 @@ class Local extends Base
 		}
 
 		// remove the root path to the config, lang and view manager objects
-		$finder->removePaths($paths);
+		if ( ! $this->factory->isMainRequest())
+		{
+			$this->component->getApplication()->getViewManager()->setFinder($originalFinder);
+		}
 
 		// log the request termination
 		$this->log->info('Request executed');

--- a/src/Request/Local.php
+++ b/src/Request/Local.php
@@ -136,10 +136,9 @@ class Local extends Base
 		array_unshift($this->route->parameters, $this->route);
 
 		// add the root path to the config, lang and view manager objects
-		if (isset($this->route->path))
-		{
-			$this->component->getApplication()->getViewManager()->getFinder()->addPath($this->route->path);
-		}
+		$paths = $this->component->getPaths();
+		$finder = $this->component->getApplication()->getViewManager()->getFinder();
+		$finder->addPaths($paths);
 
 		try
 		{
@@ -165,10 +164,7 @@ class Local extends Base
 		}
 
 		// remove the root path to the config, lang and view manager objects
-		if (isset($this->route->path))
-		{
-			$this->component->getApplication()->getViewManager()->getFinder()->removePath($this->route->path);
-		}
+		$finder->removePaths($paths);
 
 		// log the request termination
 		$this->log->info('Request executed');

--- a/src/Router.php
+++ b/src/Router.php
@@ -147,7 +147,6 @@ class Router extends \Fuel\Routing\Router
 					$class = $route->namespace.'\\'.implode('\\', array_map('ucfirst', $segments));
 					if (class_exists($class))
 					{
-						$route->path = $component->getPath();
 						$route->controller = $class;
 						break;
 					}
@@ -272,7 +271,6 @@ class Router extends \Fuel\Routing\Router
 					$class = $match->namespace.$this->namespacePrefix.'\\'.implode('\\', array_map('ucfirst', $segments));
 					if (class_exists($class))
 					{
-						$match->path = $component->getPath();
 						$match->controller = $class;
 						break;
 					}


### PR DESCRIPTION
@WanWizard until we finish to find out how to share/use (separate) contexts between requests, are you satisfied with this solution?

It is basically the same as before except all the paths are handled correctly and the finder is reseted to its original state instead of alteration.