### PR TITLE
Revert whoops

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"filp/whoops": "dev-master",
+		"filp/whoops": "~1.0",
 		"monolog/monolog": "1.6.0",
 		"league/event": "~2.0",
 		"fuelphp/dependency": "~2.0",

--- a/src/Error.php
+++ b/src/Error.php
@@ -13,7 +13,6 @@ namespace Fuel\Foundation;
 use Whoops\Run;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Handler\JsonResponseHandler;
-use function Whoops\isAjaxRequest;
 use Fuel\Foundation\Whoops\ProductionHandler;
 
 /**
@@ -211,13 +210,10 @@ class Error
 
 		$this->whoops->pushHandler($this->pagehandler);
 
-		// next on the stack goes the JSON handler, to deal with AJAX requests
-		if (isAjaxRequest())
-		{
-			$jsonHandler = new JsonResponseHandler;
-			// $jsonHandler->addTraceToOutput(true);
-			$run->addHandler($jsonHandler)
-		}
+		// next on the stack goes the JSON handler, to deal with AJAX reqqests
+		$jsonHandler = new JsonResponseHandler;
+		$jsonHandler->onlyForAjaxRequests(true);
+		// $jsonHandler->addTraceToOutput(true);
 
 		$this->whoops->pushHandler($jsonHandler);
 


### PR DESCRIPTION
When I update whoops to dev-master, it seems it does not work well.
So for the time being, I fix whoops version 1.x.

By the way, it seems the reverted whoops still can't catch a Fatal error. 
Is it okay?
