### PR TITLE
Output formatting #31

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -169,6 +169,9 @@ class Application
 
 		// route to and call controller
 		$match = $this->getRouteMatch($request);
+		$this->dependencyContainer
+			->add('fuel.application.routeMatch', $match);
+
 		$response = $this->getControllerResult($match);
 
 		// trigger request ended event

--- a/src/ApplicationServicesProvider.php
+++ b/src/ApplicationServicesProvider.php
@@ -56,26 +56,69 @@ class ApplicationServicesProvider extends AbstractServiceProvider
 		$this->getContainer()->add('fuel.application.event', 'League\Event\Emitter', true);
 
 		$this->getContainer()->add('Fuel\Foundation\Request\Cli', 'Fuel\Foundation\Request\Cli', false);
-		$this->getContainer()->add('Fuel\Foundation\Request\Http', Http::forge(), false);
-		$this->getContainer()->add('fuel.application.request', $this->constructRequest(), true);
+		$this->getContainer()->add(
+			'Fuel\Foundation\Request\Http',
+			function() {
+				return Http::forge();
+			},
+			false
+		);
+
+		$this->getContainer()->add(
+			'fuel.application.request',
+			function() {
+				return $this->constructRequest();
+			},
+			true
+		);
 
 		$this->getContainer()->add('Fuel\Foundation\Response\Cli', 'Fuel\Foundation\Response\Cli', false);
 		$this->getContainer()->add('Fuel\Foundation\Response\Http', 'Fuel\Foundation\Response\Http', false);
-		$this->getContainer()->add('fuel.application.response', $this->constructResponse(), true);
+		$this->getContainer()->add(
+			'fuel.application.response',
+			function() {
+				return $this->constructResponse();
+				},
+			true
+		);
 
 		$this->getContainer()->add('fuel.application.finder', 'Fuel\FileSystem\Finder', true);
 
 		// Also create a config container for our services
-		$this->getContainer()->add('fuel.config', new Container(null, $this->getContainer()->get('fuel.application.finder')), true);
+		$this->getContainer()->add(
+			'fuel.config',
+			function() {
+				return new Container(null, $this->getContainer()->get('fuel.application.finder'));
+			},
+			true
+		);
 
-		$this->getContainer()->add('fuel.application.component_manager', $this->constructComponentManager(), true);
+		$this->getContainer()->add(
+			'fuel.application.component_manager',
+			function () {
+				return $this->constructComponentManager();
+			},
+			true
+		);
 
-		$this->getContainer()->add('fuel.application.router', $this->constructRouter(), true);
+		$this->getContainer()->add(
+			'fuel.application.router',
+			function() {
+				return $this->constructRouter();
+			},
+			true
+		);
 
 		// Add in the various formatters
-		$this->container->add('Fuel\Foundation\Formatter\Noop', 'Fuel\Foundation\Formatter\Noop', true);
-		$this->container->add('Fuel\Foundation\Formatter\HttpAcceptJson', 'Fuel\Foundation\Formatter\HttpAcceptJson', true);
-		$this->container->add('Fuel\Foundation\ResponseFormatter', $this->constructResponseFormatter(), true);
+		$this->getContainer()->add('Fuel\Foundation\Formatter\Noop', 'Fuel\Foundation\Formatter\Noop', true);
+		$this->getContainer()->add('Fuel\Foundation\Formatter\HttpAcceptJson', 'Fuel\Foundation\Formatter\HttpAcceptJson', true);
+		$this->getContainer()->add(
+			'Fuel\Foundation\ResponseFormatter',
+			function() {
+				return $this->constructResponseFormatter();
+			},
+			true
+		);
 	}
 
 	/**

--- a/src/Exception/Formatter.php
+++ b/src/Exception/Formatter.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @package    Fuel\Foundation
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+namespace Fuel\Foundation\Exception;
+
+use RuntimeException;
+
+class Formatter extends RuntimeException
+{
+
+}

--- a/src/Exception/FormatterLoad.php
+++ b/src/Exception/FormatterLoad.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package    Fuel\Foundation
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+declare(strict_types=1);
+
+namespace Fuel\Foundation\Exception;
+
+/**
+ * Indicates an error with loading a data formatter.
+ *
+ * @package Fuel\Foundation\Exception
+ */
+class FormatterLoad extends Formatter
+{
+}

--- a/src/Formatter/AbstractFormatter.php
+++ b/src/Formatter/AbstractFormatter.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @package    Fuel\Foundation
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+declare(strict_types=1);
+
+namespace Fuel\Foundation\Formatter;
+
+use League\Container\ContainerInterface;
+
+abstract class AbstractFormatter implements FormatterInterface
+{
+	/**
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * Sets the dependency container that the formatter will use.
+	 *
+	 * @param ContainerInterface $container
+	 */
+	public function setContainer(ContainerInterface $container)
+	{
+		$this->container = $container;
+	}
+
+	/**
+	 * Gets the current dependency container.
+	 *
+	 * @return ContainerInterface
+	 */
+	public function getContainer(): ContainerInterface
+	{
+		return $this->container;
+	}
+}

--- a/src/Formatter/FormatterInterface.php
+++ b/src/Formatter/FormatterInterface.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package    Fuel\Foundation
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+declare(strict_types=1);
+
+namespace Fuel\Foundation\Formatter;
+
+use Fuel\Foundation\Response\ResponseInterface;
+use League\Container\ContainerInterface;
+
+/**
+ * Defines a common interface for taking a controller result and formatting that for return to the client.
+ */
+interface FormatterInterface
+{
+	/**
+	 * Sets the dependency container that the formatter will use.
+	 *
+	 * @param ContainerInterface $container
+	 */
+	public function setContainer(ContainerInterface $container);
+
+	/**
+	 * Gets the current dependency container.
+	 *
+	 * @return ContainerInterface
+	 */
+	public function getContainer(): ContainerInterface;
+
+	/**
+	 * Should return true if the formatter is able to handle the current data.
+	 *
+	 * @param mixed $data Result returned from the controller's action. This allows the formatter to determine if the
+	 *                    data is in a format that it can support or not.
+	 *
+	 * @return bool
+	 */
+	public function canActivate($data): bool;
+
+	/**
+	 * Should produce a ResponseInterface object that contains the formatted data and any necessary headers.
+	 *
+	 * @param mixed $data Result returned from the controller's action.
+	 *
+	 * @return ResponseInterface
+	 */
+	public function format($data): ResponseInterface;
+}

--- a/src/Formatter/HttpAcceptJson.php
+++ b/src/Formatter/HttpAcceptJson.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @package    Fuel\Foundation
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+declare(strict_types=1);
+
+namespace Fuel\Foundation\Formatter;
+
+use Fuel\Foundation\Request\RequestInterface;
+use Fuel\Foundation\Response\ResponseInterface;
+use Zend\Diactoros\CallbackStream;
+
+/**
+ * Formats data in to json if the header "Accept: application/json" is present in the request.
+ */
+class HttpAcceptJson extends AbstractFormatter
+{
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function canActivate($data) : bool
+	{
+		/** @var RequestInterface $request */
+		$request = $this->getContainer()->get('fuel.application.request');
+
+		return $request->hasHeader('Accept') &&
+			in_array('application/json', $request->getHeader('Accept'));
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function format($data) : ResponseInterface
+	{
+		/** @var ResponseInterface $response */
+		$response = $this->getContainer()->get('fuel.application.response');
+
+		return $response
+			->withBody(new CallbackStream(
+				function() use ($data) {
+					return json_encode($data);
+				}
+			))
+			->withHeader('Content-Type', 'application/json');
+	}
+}

--- a/src/Formatter/Noop.php
+++ b/src/Formatter/Noop.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package    Fuel\Foundation
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+declare(strict_types=1);
+
+namespace Fuel\Foundation\Formatter;
+
+use Fuel\Foundation\Response\ResponseInterface;
+use Zend\Diactoros\CallbackStream;
+
+/**
+ * Dummy formatter that simply passes the response right through.
+ */
+class Noop extends AbstractFormatter
+{
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function canActivate($data) : bool
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function format($data) : ResponseInterface
+	{
+		/** @var ResponseInterface $response */
+		$response = $this->getContainer()->get('fuel.application.response');
+
+		return $response->withBody(new CallbackStream(
+			function() use ($data) {
+				return $data;
+			}
+		));
+	}
+}

--- a/src/Request/Cli.php
+++ b/src/Request/Cli.php
@@ -25,4 +25,30 @@ class Cli implements RequestInterface
 	{
 		// TODO: Implement getMethod() method.
 	}
-}
+
+	public function getHeaders()
+	{
+		// TODO: Implement getHeaders() method.
+	}
+
+	/**
+	 * @param string $header
+	 *
+	 * @return bool
+	 */
+	public function hasHeader($header)
+	{
+		// TODO: Implement hasHeader() method.
+	}
+
+	/**
+	 * @param string $header Case-insensitive header field name.
+	 *
+	 * @return string[] An array of string values as provided for the given
+	 *    header. If the header does not appear in the message, this method MUST
+	 *    return an empty array.
+	 */
+	public function getHeader($header)
+	{
+		// TODO: Implement getHeader() method.
+}}

--- a/src/Request/RequestInterface.php
+++ b/src/Request/RequestInterface.php
@@ -22,4 +22,21 @@ interface RequestInterface
 	public function getUri();
 
 	public function getMethod();
+
+	public function getHeaders();
+
+	/**
+	 * @param string $header
+	 *
+	 * @return bool
+	 */
+	public function hasHeader($header);
+
+	/**
+	 * @param string $header Case-insensitive header field name.
+	 * @return string[] An array of string values as provided for the given
+	 *    header. If the header does not appear in the message, this method MUST
+	 *    return an empty array.
+	 */
+	public function getHeader($header);
 }

--- a/src/Response/Cli.php
+++ b/src/Response/Cli.php
@@ -40,4 +40,9 @@ class Cli implements ResponseInterface
 		$this->statusCode = $status;
 		return $this;
 	}
+
+	public function withHeader($header, $value)
+	{
+		// TODO: Implement withHeader() method.
+	}
 }

--- a/src/Response/ResponseInterface.php
+++ b/src/Response/ResponseInterface.php
@@ -18,9 +18,27 @@ interface ResponseInterface
 {
 	public function getStatusCode();
 
+	/**
+	 * @param StreamInterface $body
+	 *
+	 * @return ResponseInterface
+	 */
 	public function withBody(StreamInterface $body);
 
 	public function getBody();
 
+	/**
+	 * @param int $status
+	 *
+	 * @return ResponseInterface
+	 */
 	public function withStatus($status);
+
+	/**
+	 * @param string       $header
+	 * @param array|string $value
+	 *
+	 * @return ResponseInterface
+	 */
+	public function withHeader($header, $value);
 }

--- a/src/ResponseFormatter.php
+++ b/src/ResponseFormatter.php
@@ -15,6 +15,7 @@ namespace Fuel\Foundation;
 use Fuel\Foundation\Exception\Formatter;
 use Fuel\Foundation\Exception\FormatterLoad;
 use Fuel\Foundation\Formatter\FormatterInterface;
+use League\Container\ContainerInterface;
 
 /**
  * Keeps track of active formatters and facilitates the formatting of a controller response.
@@ -27,15 +28,15 @@ class ResponseFormatter
 	protected $formatterClasses = [];
 
 	/**
-	 * @var \Fuel\Dependency\Container
+	 * @var ContainerInterface
 	 */
 	protected $dependencyContainer;
 
 	/**
 	 * ResponseFormatter constructor.
 	 *
-	 * @param string[]                   $formatters          List of class names or DIC instance names
-	 * @param \Fuel\Dependency\Container $dependencyContainer
+	 * @param string[]           $formatters          List of class names or DIC instance names
+	 * @param ContainerInterface $dependencyContainer
 	 */
 	public function __construct($formatters, $dependencyContainer)
 	{

--- a/src/ResponseFormatter.php
+++ b/src/ResponseFormatter.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @package    Fuel\Foundation
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+declare(strict_types=1);
+
+namespace Fuel\Foundation;
+
+use Fuel\Foundation\Exception\Formatter;
+use Fuel\Foundation\Exception\FormatterLoad;
+use Fuel\Foundation\Formatter\FormatterInterface;
+
+/**
+ * Keeps track of active formatters and facilitates the formatting of a controller response.
+ */
+class ResponseFormatter
+{
+	/**
+	 * @var FormatterInterface[]
+	 */
+	protected $formatterClasses = [];
+
+	/**
+	 * @var \Fuel\Dependency\Container
+	 */
+	protected $dependencyContainer;
+
+	/**
+	 * ResponseFormatter constructor.
+	 *
+	 * @param string[]                   $formatters          List of class names or DIC instance names
+	 * @param \Fuel\Dependency\Container $dependencyContainer
+	 */
+	public function __construct($formatters, $dependencyContainer)
+	{
+		$this->dependencyContainer = $dependencyContainer;
+
+		foreach ($formatters as $formatter) {
+			$formatterInstance = $dependencyContainer->get($formatter);
+
+			if (! $formatterInstance instanceof FormatterInterface) {
+				throw new FormatterLoad("FOU-003: Unable to load [$formatter]: Does not implement FormatterInterface");
+			}
+
+			$formatterInstance->setContainer($dependencyContainer);
+			$this->formatterClasses[$formatter] = $formatterInstance;
+		}
+	}
+
+	/**
+	 * @return FormatterInterface[]
+	 */
+	public function getFormatters()
+	{
+		return $this->formatterClasses;
+	}
+
+	/**
+	 * @param mixed $data Result returned by the controller.
+	 *
+	 * @return FormatterInterface
+	 */
+	public function getFormatter($data)
+	{
+		foreach ($this->formatterClasses as $formatter) {
+			if ($formatter->canActivate($data)) {
+				return $formatter;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Attempts to run a registered formatter on the given data.
+	 *
+	 * @param mixed $data
+	 */
+	public function format($data)
+	{
+		$formatter = $this->getFormatter($data);
+
+		if ($formatter === null) {
+			throw new Formatter('FOU-004: No formatter could be found');
+		}
+
+		$formatter->format($data);
+	}
+}

--- a/tests/unit/ApplicationTest.php
+++ b/tests/unit/ApplicationTest.php
@@ -114,7 +114,7 @@ class ApplicationTest extends Test
 		$this->assertSame($app, $event->getApplication());
 	}
 
-	public function testMakeRequest()
+	public function testPerformRequest()
 	{
 		$requestStartCalled = false;
 		$requestStartApplication = null;
@@ -155,6 +155,11 @@ class ApplicationTest extends Test
 
 		$this->assertTrue($requestEndCalled);
 		$this->assertSame($app, $requestEndApplication);
+
+		$this->assertInstanceOf(
+			'\Fuel\Routing\Match',
+			$app->getDependencyContainer()->get('fuel.application.routeMatch')
+		);
 	}
 
 	public function testRun()

--- a/tests/unit/Formatter/HttpAcceptJsonTest.php
+++ b/tests/unit/Formatter/HttpAcceptJsonTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package    Fuel\Foundation\Test
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+declare(strict_types=1);
+
+namespace Fuel\Foundation\Test\Formatter;
+
+use Codeception\TestCase\Test;
+use Fuel\Dependency\Container;
+use Fuel\Foundation\Formatter\HttpAcceptJson;
+use Fuel\Foundation\Request\Http as HttpRequest;
+use Fuel\Foundation\Request\Http;
+use Fuel\Foundation\Response\Http as HttpResponse;
+
+class HttpAcceptJsonTest extends Test
+{
+	public function testCanActivate()
+	{
+		$json = new HttpAcceptJson();
+
+		$container = new Container();
+		$json->setContainer($container);
+
+		$container->add('fuel.application.request', new HttpRequest([], [], null, null, 'php://input', ['Accept' => 'application/json']));
+		$container->add('fuel.application.response', new HttpResponse());
+
+		$this->assertTrue($json->canActivate(null));
+
+		$container->add('fuel.application.request', new HttpRequest([], [], null, null, 'php://input', ['Accept' => ['text/html', 'application/json']]));
+		$container->add('fuel.application.response', new HttpResponse());
+
+		$this->assertTrue($json->canActivate(null));
+
+		$container->add('fuel.application.request', new HttpRequest([], [], null, null, 'php://input', ['Accept' => 'text/html']));
+		$container->add('fuel.application.response', new HttpResponse());
+
+		$this->assertFalse($json->canActivate(null));
+	}
+
+	public function testFormat()
+	{
+		$json = new HttpAcceptJson();
+
+		$container = new Container();
+		$json->setContainer($container);
+
+		$container->add('fuel.application.request', new HttpRequest([], [], null, null, 'php://input', ['Accept' => 'application/json']));
+		$container->add('fuel.application.response', new HttpResponse());
+
+		$result = $json->format(['foo' => 'bar', 'true' => false]);
+
+		$this->assertEquals(
+			'{"foo":"bar","true":false}',
+			(string) $result->getBody()
+		);
+	}
+}

--- a/tests/unit/Formatter/NoopTest.php
+++ b/tests/unit/Formatter/NoopTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package    Fuel\Foundation\Test
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+declare(strict_types=1);
+
+namespace Fuel\Foundation\Test\Formatter;
+
+use Codeception\TestCase\Test;
+use Fuel\Dependency\Container;
+use Fuel\Foundation\Formatter\Noop;
+use Fuel\Foundation\Response\Http as HttpResponse;
+
+class NoopTest extends Test
+{
+	public function testCanActivate()
+	{
+		$noop = new Noop();
+
+		$this->assertTrue($noop->canActivate(null));
+	}
+
+	public function testFormat()
+	{
+		$noop = new Noop();
+
+		$response = new HttpResponse();
+
+		$container = new Container();
+		$container->add('fuel.application.response', $response);
+		$noop->setContainer($container);
+
+		$result = $noop->format('foobar');
+
+		$this->assertEquals(
+			'foobar',
+			(string) $result->getBody()
+		);
+	}
+}

--- a/tests/unit/ResponseFormatterTest.php
+++ b/tests/unit/ResponseFormatterTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @package    Fuel\Foundation\Test
+ * @version    2.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2017 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+namespace Fuel\Foundation\Test;
+
+use Codeception\TestCase\Test;
+use Fuel\Dependency\Container;
+use Fuel\Foundation\ResponseFormatter;
+use Mockery;
+
+class ResponseFormatterTest extends Test
+{
+	/**
+	 * @var Container
+	 */
+	protected $dependencyContainer;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->dependencyContainer = new Container();
+	}
+
+	public function testConstruct()
+	{
+		$this->dependencyContainer->add('fuel.response.formatter.noop', 'Fuel\Foundation\Formatter\Noop');
+
+		$instance = new ResponseFormatter(['fuel.response.formatter.noop'], $this->dependencyContainer);
+
+		$this->assertInstanceOf(
+			'Fuel\Foundation\Formatter\Noop',
+			$instance->getFormatters()['fuel.response.formatter.noop']);
+	}
+
+	/**
+	 * @expectedException \Fuel\Foundation\Exception\FormatterLoad
+	 * @expectedExceptionMessage FOU-003: Unable to load [fuel.response.formatter.noop]: Does not implement FormatterInterface
+	 */
+	public function testConstructWithInvalidFormatter()
+	{
+		$this->dependencyContainer->add('fuel.response.formatter.noop', 'stdClass');
+
+		new ResponseFormatter(['fuel.response.formatter.noop'], $this->dependencyContainer);
+	}
+
+	public function testCanFormatNegative()
+	{
+		$instance = new ResponseFormatter([], $this->dependencyContainer);
+		$this->assertNull($instance->getFormatter([]));
+	}
+
+	public function testCanFormatPositive()
+	{
+		$this->dependencyContainer->add('fuel.response.formatter.noop', 'Fuel\Foundation\Formatter\Noop');
+
+		$instance = new ResponseFormatter(['fuel.response.formatter.noop'], $this->dependencyContainer);
+
+		$this->assertInstanceOf(
+			'Fuel\Foundation\Formatter\Noop',
+			$instance->getFormatter([])
+		);
+	}
+
+	/**
+	 * @expectedException  \Fuel\Foundation\Exception\Formatter
+	 * @expectedExceptionMessage FOU-004: No formatter could be found
+	 */
+	public function testFormatWithNoFormatters()
+	{
+		$instance = new ResponseFormatter([], $this->dependencyContainer);
+		$instance->format([]);
+	}
+
+	public function testFormat()
+	{
+		/** @var \Mockery\Mock $formatterMock */
+		$formatterMock = Mockery::mock('\Fuel\Foundation\Formatter\FormatterInterface');
+
+		$formatterMock
+			->shouldReceive('setContainer')
+			->with($this->dependencyContainer)
+			->once();
+
+		$formatterMock
+			->shouldReceive('canActivate')
+			->with(['foo' => 'bar'])
+			->once()
+			->andReturn(true);
+
+		$formatterMock
+			->shouldReceive('format')
+			->with(['foo' => 'bar'])
+			->once();
+
+		$this->dependencyContainer->add('formatter.test', $formatterMock);
+
+		$instance = new ResponseFormatter(['formatter.test'], $this->dependencyContainer);
+		$instance->format(['foo' => 'bar']);
+	}
+}


### PR DESCRIPTION
Initial implementation for #31. This provides the basic framework to be able to format requests, at the moment it would be hooked in using the existing events config when bootstrapping the application making this fully configurable by the developer.

 Once this is merged in I'll update fuelphp/fuelphp to use the new functionality and implement and automatic view loader to replicate the current v1 functionality.